### PR TITLE
Replace deprecated PIL.Image.LINEAR with PIL.Image.BILINEAR

### DIFF
--- a/detectron2/data/transforms/transform.py
+++ b/detectron2/data/transforms/transform.py
@@ -43,7 +43,7 @@ class ExtentTransform(Transform):
     See: https://pillow.readthedocs.io/en/latest/PIL.html#PIL.ImageTransform.ExtentTransform
     """
 
-    def __init__(self, src_rect, output_size, interp=Image.LINEAR, fill=0):
+    def __init__(self, src_rect, output_size, interp=Image.BILINEAR, fill=0):
         """
         Args:
             src_rect (x0, y0, x1, y1): src coordinates


### PR DESCRIPTION
The Pillow 10.0.0 is released on July 1 and deprecated PIL.Image.LINEAR in favor or PIL.Image.BILINEAR.

See [detectron2 issue](https://github.com/facebookresearch/detectron2/issues/5010) for the fix